### PR TITLE
struct macro gives an error if the struct only has one member

### DIFF
--- a/src/main/scala/com/gu/scanamo/scrooge/ScroogeDynamoFormat.scala
+++ b/src/main/scala/com/gu/scanamo/scrooge/ScroogeDynamoFormat.scala
@@ -61,11 +61,17 @@ class ScroogeDynamoFormatMacro(val c: blackbox.Context) {
       (writer, reader, fresh, freshSuccesful)
     }
 
+    val reducedWriter = if(params.length != 1)
+      q"""List(..${params.map(_._3)}).reduce(_.product(_))"""
+    else
+      q"""${params.head._3}"""
+
     q"""
       new com.gu.scanamo.DynamoFormat[$A] {
         def read(av: com.amazonaws.services.dynamodbv2.model.AttributeValue): cats.data.Xor[com.gu.scanamo.error.DynamoReadError, $A] = {
           ..${params.map(_._2)}
-          List(..${params.map(_._3)}).reduce(_.product(_)).toXor.map(_ =>
+
+          ${reducedWriter}.toXor.map(_ =>
             ${apply.asMethod}(
               ..${params.map(_._4)}
             )

--- a/src/test/scala/com/gu/scanamo/scrooge/ScroogeDynamoFormatTest.scala
+++ b/src/test/scala/com/gu/scanamo/scrooge/ScroogeDynamoFormatTest.scala
@@ -2,7 +2,7 @@ package com.gu.scanamo.scrooge
 
 import cats.data.Xor
 import com.amazonaws.services.dynamodbv2.model.AttributeValue
-import com.gu.contentatom.thrift.{ChangeRecord, User}
+import com.gu.contentatom.thrift.{ChangeRecord, User, Flags}
 import com.gu.contentatom.thrift.atom.media.AssetType
 import com.gu.scanamo.DynamoFormat
 import com.gu.scanamo.error.TypeCoercionError
@@ -22,4 +22,11 @@ class ScroogeDynamoFormatTest extends FunSuite with Matchers {
     val changeRecord = ChangeRecord(1L, Some(User("email", Some("f"), None)))
     DynamoFormat[ChangeRecord].read(DynamoFormat[ChangeRecord].write(changeRecord)) should be(Xor.right(changeRecord))
   }
+
+  test("testScroogeScanamoStructFormat for struct with one member") {
+    import ScroogeDynamoFormat._
+    val flags = Flags(Some(true))
+    DynamoFormat[Flags].read(DynamoFormat[Flags].write(flags)) should be(Xor.right(flags))
+  }
+
 }


### PR DESCRIPTION
The struct macro didn't work on the struct `Flags` in the `content-atom` model, because it is a struct that currently only has one member (so the expanded reduce code won't compile). I have added a test the reproduces this problem, and I have provided a suggested fix.

Thanks, -Paul