### PR TITLE
Use normal implicit resolution if possible

### DIFF
--- a/src/test/scala/com/gu/scanamo/scrooge/ScroogeDynamoFormatTest.scala
+++ b/src/test/scala/com/gu/scanamo/scrooge/ScroogeDynamoFormatTest.scala
@@ -5,7 +5,6 @@ import com.amazonaws.services.dynamodbv2.model.AttributeValue
 import com.gu.contentatom.thrift.{ChangeRecord, User}
 import com.gu.contentatom.thrift.atom.media.AssetType
 import com.gu.scanamo.DynamoFormat
-import com.gu.scanamo.error.TypeCoercionError
 import org.scalatest.{FunSuite, Matchers}
 
 class ScroogeDynamoFormatTest extends FunSuite with Matchers {


### PR DESCRIPTION
This is based on @cb372's work in https://github.com/guardian/content-api-models/pull/43/files