### PR TITLE
fix incompatability with cats-0.7.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -15,6 +15,8 @@ libraryDependencies ++= Seq(
   "com.gu" %% "content-atom-model" % "1.0.1" % Test
 )
 
+scroogeThriftOutputFolder in Test := sourceManaged.value / "thrift"
+
 doctestMarkdownEnabled := true
 doctestDecodeHtmlEntities := true
 doctestWithDependencies := false

--- a/build.sbt
+++ b/build.sbt
@@ -7,12 +7,12 @@ libraryDependencies ++= Seq(
   "org.scala-lang" % "scala-reflect" % scalaVersion.value,
 	"com.twitter" %% "scrooge-core" % "3.20.0",
 	"org.apache.thrift" % "libthrift" % "0.9.2",
-  "com.gu" %% "scanamo" % "0.6.0",
+  "com.gu" %% "scanamo" % "0.7.0",
   "org.typelevel" %% "macro-compat" % "1.1.1",
   compilerPlugin("org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.full),
   "org.scalatest" %% "scalatest" % "2.2.5" % Test,
   "org.scalacheck" %% "scalacheck" % "1.12.4" % Test,
-  "com.gu" %% "content-atom-model" % "1.0.1" % Test
+  "com.gu" %% "content-atom-model" % "2.4.6" % Test
 )
 
 scroogeThriftOutputFolder in Test := sourceManaged.value / "thrift"

--- a/src/main/scala/com/gu/scanamo/scrooge/ScroogeDynamoFormat.scala
+++ b/src/main/scala/com/gu/scanamo/scrooge/ScroogeDynamoFormat.scala
@@ -61,7 +61,7 @@ class ScroogeDynamoFormatMacro(val c: blackbox.Context) {
             val format = $formatWithFallback
             val possibleValue = collection.convert.WrapAsScala.mapAsScalaMap(av.getM).get(${termName.toString}).map(format.read).orElse(format.default.map(cats.data.Xor.right))
             val validatedValue = possibleValue.getOrElse(cats.data.Xor.left[com.gu.scanamo.error.DynamoReadError, $tpe](com.gu.scanamo.error.MissingProperty))
-            validatedValue.leftMap(e => com.gu.scanamo.error.InvalidPropertiesError(cats.data.NonEmptyList(com.gu.scanamo.error.PropertyReadError(${termName.toString}, e)))).toValidated
+            validatedValue.leftMap(e => com.gu.scanamo.error.InvalidPropertiesError(cats.data.NonEmptyList(com.gu.scanamo.error.PropertyReadError(${termName.toString}, e), Nil))).toValidated
           }
           """
       val writer = q"""${termName.toString} -> _root_.scala.Predef.implicitly[_root_.shapeless.Lazy[_root_.com.gu.scanamo.DynamoFormat[$tpe]]].value.write(t.$termName)"""

--- a/src/main/scala/com/gu/scanamo/scrooge/ScroogeDynamoFormat.scala
+++ b/src/main/scala/com/gu/scanamo/scrooge/ScroogeDynamoFormat.scala
@@ -61,7 +61,7 @@ class ScroogeDynamoFormatMacro(val c: blackbox.Context) {
             val format = $formatWithFallback
             val possibleValue = collection.convert.WrapAsScala.mapAsScalaMap(av.getM).get(${termName.toString}).map(format.read).orElse(format.default.map(cats.data.Xor.right))
             val validatedValue = possibleValue.getOrElse(cats.data.Xor.left[com.gu.scanamo.error.DynamoReadError, $tpe](com.gu.scanamo.error.MissingProperty))
-            validatedValue.leftMap(e => com.gu.scanamo.error.InvalidPropertiesError(cats.data.NonEmptyList(com.gu.scanamo.error.PropertyReadError(${termName.toString}, e), Nil))).toValidated
+            validatedValue.leftMap(e => com.gu.scanamo.error.InvalidPropertiesError(cats.data.NonEmptyList.of(com.gu.scanamo.error.PropertyReadError(${termName.toString}, e)))).toValidated
           }
           """
       val writer = q"""${termName.toString} -> _root_.scala.Predef.implicitly[_root_.shapeless.Lazy[_root_.com.gu.scanamo.DynamoFormat[$tpe]]].value.write(t.$termName)"""

--- a/src/main/scala/com/gu/scanamo/scrooge/ScroogeDynamoFormat.scala
+++ b/src/main/scala/com/gu/scanamo/scrooge/ScroogeDynamoFormat.scala
@@ -70,7 +70,7 @@ class ScroogeDynamoFormatMacro(val c: blackbox.Context) {
     }
 
     val reducedWriter = if(params.length != 1)
-      q"""List(..${params.map(_._3)}).reduce(_.product(_))"""
+      q"""List[cats.data.Validated[com.gu.scanamo.error.InvalidPropertiesError, Any]](..${params.map(_._3)}).reduce(_.product(_))"""
     else
       q"""${params.head._3}"""
 


### PR DESCRIPTION
a change in cats-0.7.0 breaks the macro expansion here. Not an issue in itself as this repo doesn't depend on that version of cats, but when it is combined with a project that uses the latest version of scanamo, which does bring in that version of cats, we get a problem.

See, for example, https://github.com/guardian/atom-maker/pull/1