### PR TITLE
Bump scrooge-related dependencies

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,18 +1,18 @@
 name := "scanamo-scrooge"
 organization := "com.gu"
 
-scalaVersion := "2.11.8"
+scalaVersion := "2.11.12"
 
 libraryDependencies ++= Seq(
   "org.scala-lang" % "scala-reflect" % scalaVersion.value,
-	"com.twitter" %% "scrooge-core" % "3.20.0",
-	"org.apache.thrift" % "libthrift" % "0.9.2",
+	"com.twitter" %% "scrooge-core" % "19.3.0",
+	"org.apache.thrift" % "libthrift" % "0.10.0",
   "com.gu" %% "scanamo" % "0.9.0",
   "org.typelevel" %% "macro-compat" % "1.1.1",
   compilerPlugin("org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.full),
   "org.scalatest" %% "scalatest" % "2.2.5" % Test,
   "org.scalacheck" %% "scalacheck" % "1.12.4" % Test,
-  "com.gu" %% "content-atom-model" % "2.4.30" % Test
+  "com.gu" %% "content-atom-model" % "3.0.2" % Test
 )
 
 scroogeThriftOutputFolder in Test := sourceManaged.value / "thrift"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,8 +1,4 @@
-// Scrooge relies on an ancient version of thrift that's not on maven central
-// Instead, force a slightly more recent version
-libraryDependencies += "org.apache.thrift" % "libthrift" % "0.6.1"
-
-addSbtPlugin("com.twitter" %% "scrooge-sbt-plugin" % "3.18.1")
+addSbtPlugin("com.twitter" %% "scrooge-sbt-plugin" % "19.3.0")
 
 addSbtPlugin("com.localytics" % "sbt-dynamodb" % "1.4.0")
 


### PR DESCRIPTION
Part of a whole bunch of upgrades to remove any trace of libthrift 0.9 across the board so that model changes do not trigger the backwards-incompatible change that was made between 0.9.1 and 0.9.2.