### PR TITLE
Bump scala to 2.12, sbt to 1.7.1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,17 +1,17 @@
 name := "scanamo-scrooge"
 organization := "com.gu"
 
-scalaVersion := "2.11.12"
+scalaVersion := "2.12.16"
 
 libraryDependencies ++= Seq(
   "org.scala-lang" % "scala-reflect" % scalaVersion.value,
-	"com.twitter" %% "scrooge-core" % "19.3.0",
+	"com.twitter" %% "scrooge-core" % "22.4.0",
 	"org.apache.thrift" % "libthrift" % "0.10.0",
-  "org.scanamo" % "scanamo_2.11" % "1.0.0-M9",
+  "org.scanamo" % "scanamo_2.12" % "1.0.0-M19",
   "org.typelevel" %% "macro-compat" % "1.1.1",
-  compilerPlugin("org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.full),
-  "org.scalatest" %% "scalatest" % "2.2.5" % Test,
-  "org.scalacheck" %% "scalacheck" % "1.12.4" % Test,
+  compilerPlugin("org.scalamacros" % "paradise" % "2.1.1" cross CrossVersion.full),
+  "org.scalatest" %% "scalatest" % "3.2.12" % Test,
+  "org.scalacheck" %% "scalacheck" % "1.16.0" % Test,
   "com.gu" %% "content-atom-model" % "3.0.2" % Test
 )
 

--- a/build.sbt
+++ b/build.sbt
@@ -7,25 +7,28 @@ libraryDependencies ++= Seq(
   "org.scala-lang" % "scala-reflect" % scalaVersion.value,
 	"com.twitter" %% "scrooge-core" % "22.4.0",
 	"org.apache.thrift" % "libthrift" % "0.10.0",
-  "org.scanamo" % "scanamo_2.12" % "1.0.0-M19",
-  "org.typelevel" %% "macro-compat" % "1.1.1",
+  "org.scanamo" % "scanamo_2.12" % "1.0.0-M9",
   compilerPlugin("org.scalamacros" % "paradise" % "2.1.1" cross CrossVersion.full),
   "org.scalatest" %% "scalatest" % "3.2.12" % Test,
+  "org.scalatest" %% "scalatest-funspec" % "3.2.12" % Test,
   "org.scalacheck" %% "scalacheck" % "1.16.0" % Test,
   "com.gu" %% "content-atom-model" % "3.0.2" % Test
 )
 
-scroogeThriftOutputFolder in Test := sourceManaged.value / "thrift"
+// Necessary because of a conflict between catz, imported by scanamo 1.0.0M9, and scanamo-scrooge
+dependencyOverrides += "org.scala-lang.modules" %% "scala-collection-compat" % "2.4.4"
+
+Test / scroogeThriftOutputFolder := sourceManaged.value / "thrift"
 
 doctestMarkdownEnabled := true
 doctestDecodeHtmlEntities := true
-doctestWithDependencies := false
 doctestTestFramework := DoctestTestFramework.ScalaTest
 
 homepage := Some(url("https://github.com/guardian/scanamo-scrooge"))
-licenses := Seq("Apache V2" -> url("http://www.apache.org/licenses/LICENSE-2.0.html"))
+licenses := Seq("Apache V2" -> url("https://www.apache.org/licenses/LICENSE-2.0.html"))
 publishMavenStyle := true
-publishArtifact in Test := false
+Test / publishArtifact := false
+
 scmInfo := Some(ScmInfo(
   url("https://github.com/guardian/scanamo-scrooge"),
   "scm:git:git@github.com:guardian/scanamo-scrooge.git"
@@ -56,3 +59,6 @@ releaseProcess := Seq[ReleaseStep](
   ReleaseStep(action = Command.process("sonatypeReleaseAll", _)),
   pushChanges
 )
+
+
+

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.11
+sbt.version=1.7.1

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,19 +1,19 @@
 addSbtPlugin("com.twitter" %% "scrooge-sbt-plugin" % "19.3.0")
 
-addSbtPlugin("com.localytics" % "sbt-dynamodb" % "1.5.5")
+addSbtPlugin("com.localytics" % "sbt-dynamodb" % "2.0.3")
 
-addSbtPlugin("com.github.tkawachi" % "sbt-doctest" % "0.4.0")
+addSbtPlugin("com.github.tkawachi" % "sbt-doctest" % "0.10.0")
 
-resolvers += "jgit-repo" at "http://download.eclipse.org/jgit/maven"
-addSbtPlugin("com.typesafe.sbt" % "sbt-ghpages" % "0.5.4")
-addSbtPlugin("com.typesafe.sbt" % "sbt-site" % "0.8.2")
+resolvers += "jgit-repo" at "https://download.eclipse.org/jgit/maven"
 
-addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.0")
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "0.5.0")
-addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
+addSbtPlugin("com.typesafe.sbt" % "sbt-ghpages" % "0.6.3")
+addSbtPlugin("com.typesafe.sbt" % "sbt-site" % "1.4.1")
 
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.1")
-addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.1.0")
+addSbtPlugin("com.github.sbt" % "sbt-release" % "1.1.0")
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.13")
+addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.1.2")
 
-addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.10.0-RC1")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.8.2")
+addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.3.2")
+
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,6 @@
 addSbtPlugin("com.twitter" %% "scrooge-sbt-plugin" % "19.3.0")
 
-addSbtPlugin("com.localytics" % "sbt-dynamodb" % "1.4.0")
+addSbtPlugin("com.localytics" % "sbt-dynamodb" % "1.5.5")
 
 addSbtPlugin("com.github.tkawachi" % "sbt-doctest" % "0.4.0")
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -12,7 +12,7 @@ addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.0")
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "0.5.0")
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
 
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.3.5")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.1")
 addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.1.0")
 
 addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.10.0-RC1")

--- a/src/test/scala/com/gu/scanamo/scrooge/ScroogeDynamoFormatTest.scala
+++ b/src/test/scala/com/gu/scanamo/scrooge/ScroogeDynamoFormatTest.scala
@@ -1,13 +1,14 @@
 package org.scanamo.scrooge
 
-import com.amazonaws.services.dynamodbv2.model.AttributeValue
 import com.gu.contentatom.thrift._
 import com.gu.contentatom.thrift.atom.media._
 import org.scanamo.DynamoFormat
-import org.scalatest.{FunSuite, Matchers}
 import cats.syntax.either._
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue
 
-class ScroogeDynamoFormatTest extends FunSuite with Matchers {
+class ScroogeDynamoFormatTest extends AnyFunSuite with Matchers {
 
   def roundTrip[A : DynamoFormat](a: A) = {
     DynamoFormat[A].read(DynamoFormat[A].write(a)) should be(Right(a))
@@ -17,7 +18,7 @@ class ScroogeDynamoFormatTest extends FunSuite with Matchers {
     val format = ScroogeDynamoFormat.scroogeScanamoEnumFormat[AssetType]
     format.read(format.write(AssetType.Audio)) should be(Right(AssetType.Audio))
     format.read(format.write(AssetType.Video)) should be(Right(AssetType.Video))
-    format.read(new AttributeValue().withS("Spleurk")).isLeft should be(true)
+    format.read(AttributeValue.builder().s("Spleurk").build()).isLeft should be(true)
   }
 
   test("testScroogeScanamoStructFormat Media Atom") {

--- a/src/test/scala/com/gu/scanamo/scrooge/ScroogeDynamoFormatTest.scala
+++ b/src/test/scala/com/gu/scanamo/scrooge/ScroogeDynamoFormatTest.scala
@@ -1,12 +1,12 @@
 package org.scanamo.scrooge
 
+import com.amazonaws.services.dynamodbv2.model.AttributeValue
 import com.gu.contentatom.thrift._
 import com.gu.contentatom.thrift.atom.media._
 import org.scanamo.DynamoFormat
 import cats.syntax.either._
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
-import software.amazon.awssdk.services.dynamodb.model.AttributeValue
 
 class ScroogeDynamoFormatTest extends AnyFunSuite with Matchers {
 
@@ -18,7 +18,7 @@ class ScroogeDynamoFormatTest extends AnyFunSuite with Matchers {
     val format = ScroogeDynamoFormat.scroogeScanamoEnumFormat[AssetType]
     format.read(format.write(AssetType.Audio)) should be(Right(AssetType.Audio))
     format.read(format.write(AssetType.Video)) should be(Right(AssetType.Video))
-    format.read(AttributeValue.builder().s("Spleurk").build()).isLeft should be(true)
+    format.read(new AttributeValue().withS("Spleurk")).isLeft should be(true)
   }
 
   test("testScroogeScanamoStructFormat Media Atom") {

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.2.2-SNAPSHOT"
+ThisBuild / version := "0.2.2-SNAPSHOT"


### PR DESCRIPTION
## What does this change?

Bumps Scala to 2.12 and sbt to 1.7.1.

## How to test

Release this package locally and test in a consuming application. Does it behave as expected?

Tested in [atom-maker.](https://github.com/guardian/atom-maker)